### PR TITLE
Adding call .UseApplicationInsights() in VotingWeb

### DIFF
--- a/VotingWeb/VotingWeb.cs
+++ b/VotingWeb/VotingWeb.cs
@@ -52,6 +52,7 @@ namespace VotingWeb
                                             .AddSingleton<StatelessServiceContext>(serviceContext))
                                     .UseContentRoot(Directory.GetCurrentDirectory())
                                     .UseStartup<Startup>()
+                                    .UseApplicationInsights()
                                     .UseServiceFabricIntegration(listener, ServiceFabricIntegrationOptions.None)
                                     .UseUrls(url)
                                     .Build();


### PR DESCRIPTION
VotingData listeners setup has a call to initialize Application Insights. 
VotingWeb does not.

The missing call makes the tutorial "Tutorial: monitor and diagnose an ASP.NET Core application on Service Fabric" located [here](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-tutorial-monitoring-aspnet) to not work properly.