### PR TITLE
fix #issue10 add env variable for reverseproxy base uri into servicemanifest.xml

### DIFF
--- a/VotingWeb/Controllers/VotesController.cs
+++ b/VotingWeb/Controllers/VotesController.cs
@@ -23,6 +23,7 @@ namespace VotingWeb.Controllers
     {
         private readonly HttpClient httpClient;
         private readonly FabricClient fabricClient;
+        private readonly string reverseProxyBaseUri;
         private readonly StatelessServiceContext serviceContext;
 
         public VotesController(HttpClient httpClient, StatelessServiceContext context, FabricClient fabricClient)
@@ -30,6 +31,7 @@ namespace VotingWeb.Controllers
             this.fabricClient = fabricClient;
             this.httpClient = httpClient;
             this.serviceContext = context;
+            this.reverseProxyBaseUri = Environment.GetEnvironmentVariable("ReverseProxyBaseUri");
         }
 
         // GET: api/Votes
@@ -113,7 +115,7 @@ namespace VotingWeb.Controllers
         /// <returns></returns>
         private Uri GetProxyAddress(Uri serviceName)
         {
-            return new Uri($"http://localhost:19081{serviceName.AbsolutePath}");
+            return new Uri($"{this.reverseProxyBaseUri}{serviceName.AbsolutePath}");
         }
 
         /// <summary>

--- a/VotingWeb/PackageRoot/ServiceManifest.xml
+++ b/VotingWeb/PackageRoot/ServiceManifest.xml
@@ -18,6 +18,9 @@
         <WorkingFolder>CodePackage</WorkingFolder>
       </ExeHost>
     </EntryPoint>
+    <EnvironmentVariables>
+        <EnvironmentVariable Name="ReverseProxyBaseUri" Value="http://localhost:19081"/>
+    </EnvironmentVariables>
   </CodePackage>
 
   <!-- Config package is the contents of the Config directoy under PackageRoot that contains an 


### PR DESCRIPTION
issue: unable to change protocol or port for reverseproxy without changing code
resolution: create ReverseProxyBaseUri environment variable in servicemanifest.xml
modify service-fabric-quickstart-dotnet documentation
https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-quickstart-dotnet

